### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -1,4 +1,6 @@
 name: contoso-traders-app-deployment
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1370/Hope-Hackathon1/security/code-scanning/3](https://github.com/github-cloudlabsuser-1370/Hope-Hackathon1/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading repository contents and does not appear to require write access, we can set `contents: read` at the root level of the workflow. This will apply to all jobs unless overridden by job-specific permissions.

The `permissions` block should be added immediately after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
